### PR TITLE
The universal property for functors out of a discrete category.

### DIFF
--- a/idris-ct.ipkg
+++ b/idris-ct.ipkg
@@ -82,6 +82,10 @@ modules
   , Product.ProductCategory
   , Product.ProductFunctor
   , Profunctors.Profunctor
+  , Slice.Comma
+  , Slice.OverCategory
+  , Slice.UnderCategory
+  , Unit.UnitCategory
   , CategoryReasoning
   , Utils
 

--- a/src/Discrete/FunctionAsFunctor.lidr
+++ b/src/Discrete/FunctionAsFunctor.lidr
@@ -28,23 +28,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 > %access public export
 > %default total
 >
-> functionMapMor : (f : a -> b) -> (x, y : a) -> DiscreteMorphism x y -> DiscreteMorphism (f x) (f y)
-> functionMapMor f x x Refl = Refl
+> discreteMapMor : {a : Type} -> {cat : Category}
+>   -> (f : a -> obj cat) -> (x, y : a)
+>   -> DiscreteMorphism x y -> mor cat (f x) (f y)
+> discreteMapMor {a} {cat} f x x Refl = identity cat (f x)
 >
-> functionPreserveCompose :
->      (f : a -> b)
->   -> (x, y, z : a)
->   -> (g : DiscreteMorphism x y)
->   -> (h : DiscreteMorphism y z)
->   -> functionMapMor f x z (discreteCompose x y z g h)
->    = discreteCompose (f x) (f y) (f z) (functionMapMor f x y g) (functionMapMor f y z h)
-> functionPreserveCompose f x x x Refl Refl = Refl
+> discretePreserveCompose : (a : Type) -> (cat : Category)
+>   -> (f : a -> obj cat)
+>   -> (x : a) -> (y : a) -> (z : a)
+>   -> (g : x = y) -> (h : y = z)
+>   ->     discreteMapMor f x z (discreteCompose x y z g h)
+>        = compose cat (f x) (f y) (f z) (discreteMapMor f x y g) (discreteMapMor f y z h)
+> discretePreserveCompose a cat f x x x Refl Refl = (sym (leftIdentity cat _ _ _))
 >
-> functionAsFunctor :
->      (f : a -> b)
->   -> CFunctor (discreteCategory a) (discreteCategory b)
-> functionAsFunctor f = MkCFunctor
+> discreteFunctor : (f : a -> obj cat) -> CFunctor (discreteCategory a) cat
+> discreteFunctor {a} {cat} f = MkCFunctor
 >   f
->   (functionMapMor f)
->   (\_ => Refl)
->   (functionPreserveCompose f)
+>   (discreteMapMor {a} {cat} f)
+>   (\ _ => Refl)
+>   (discretePreserveCompose a cat f)

--- a/src/Slice/Comma.lidr
+++ b/src/Slice/Comma.lidr
@@ -1,0 +1,162 @@
+\iffalse
+SPDX-License-Identifier: AGPL-3.0-only
+
+This file is part of `idris-ct` Category Theory in Idris library.
+
+Copyright (C) 2020 Stichting Statebox <https://statebox.nl>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+\fi 
+
+> module Slice.Comma
+>
+> import Basic.Category
+> import Basic.Functor
+> import Utils
+>
+> %access public export
+> %default total
+> %auto_implicits off
+>
+> {-
+> -- Would love to put all this in a parameters block, to avoid parametrising
+> -- everything in sight over cat, cat1, cat2, fun1 and fun2 but for some reason
+> -- I can't get it to work.
+> -}
+>
+> record CommaObject (cat : Category) (cat1 : Category) (cat2 : Category)
+>     (fun1 : CFunctor cat1 cat) (fun2 : CFunctor cat2 cat)
+>   where
+>     constructor MkCommaObject
+>     comObj1 : obj cat1
+>     comObj2 : obj cat2
+>     comMor : mor cat (mapObj fun1 comObj1) (mapObj fun2 comObj2)
+>
+> record CommaMorphism (cat : Category) (cat1 : Category) (cat2 : Category)
+>     (fun1 : CFunctor cat1 cat) (fun2 : CFunctor cat2 cat)
+>     (x : CommaObject cat cat1 cat2 fun1 fun2)
+>     (y : CommaObject cat cat1 cat2 fun1 fun2)
+>   where
+>     constructor MkCommaMorphism
+>     comMor1 : mor cat1 (comObj1 x) (comObj1 y)
+>     comMor2 : mor cat2 (comObj2 x) (comObj2 y)
+>     comSq : compose cat (mapObj fun1 (comObj1 x)) (mapObj fun1 (comObj1 y)) (mapObj fun2 (comObj2 y))
+>               (mapMor fun1 _ _ comMor1) (comMor y)
+>           = compose cat (mapObj fun1 (comObj1 x)) (mapObj fun2 (comObj2 x)) (mapObj fun2 (comObj2 y))
+>               (comMor x) (mapMor fun2 _ _ comMor2)
+>
+> commaMorphismsEqual :
+>       (cat, cat1, cat2 : Category)
+>    -> (fun1 : CFunctor cat1 cat)
+>    -> (fun2 : CFunctor cat2 cat)
+>    -> (x, y : CommaObject cat cat1 cat2 fun1 fun2)
+>    -> (u, v : CommaMorphism cat cat1 cat2 fun1 fun2 x y)
+>    -> comMor1 u = comMor1 v
+>    -> comMor2 u = comMor2 v
+>    -> u = v
+> commaMorphismsEqual cat cat1 cat2 fun1 fun2 x y (MkCommaMorphism u1 u2 s) (MkCommaMorphism u1 u2 t) Refl Refl = cong {f = MkCommaMorphism u1 u2} (equalitiesEqual _ _)
+>
+> commaIdentity :
+>        (cat, cat1, cat2 : Category)
+>     -> (fun1 : CFunctor cat1 cat)
+>     -> (fun2 : CFunctor cat2 cat)
+>     -> (x : CommaObject cat cat1 cat2 fun1 fun2)
+>     -> CommaMorphism cat cat1 cat2 fun1 fun2 x x
+> commaIdentity cat cat1 cat2 fun1 fun2 x = MkCommaMorphism
+>   (identity cat1 (comObj1 x))
+>   (identity cat2 (comObj2 x))
+>   (trans
+>     (trans
+>       (cong2 {f = compose cat _ _ _} (preserveId fun1 (comObj1 x)) Refl)
+>       (leftIdentity cat _ _ (comMor x)))
+>     (sym (trans
+>       (cong {f = compose cat _ _ _ _} (preserveId fun2 (comObj2 x)))
+>       (rightIdentity cat _ _ (comMor x)))))
+>
+>
+> {-
+>    -- The diagram chase below is as follows:
+>             F_1(u_1;v_1);h
+>           = (F_1(u_1);F_1(v_1));h
+>           = F_1(u_1);(F_1(v_1);h)
+>           = F_1(u_1);(g;F_2(v_2))
+>           = (F_1(u_1);g);F_2(v_2)
+>           = (f;F_2(u_2));F_2(v_2)
+>           = f;(F_2(u_2);F_2(v_2))
+>           = f;F_2(u_2;v_2)
+>   -}
+>
+> commaCompose :
+>      (cat, cat1, cat2 : Category)
+>   -> (fun1 : CFunctor cat1 cat)
+>   -> (fun2 : CFunctor cat2 cat)
+>   -> (x, y, z : CommaObject cat cat1 cat2 fun1 fun2)
+>   -> (u : CommaMorphism cat cat1 cat2 fun1 fun2 x y)
+>   -> (v : CommaMorphism cat cat1 cat2 fun1 fun2 y z)
+>   -> CommaMorphism cat cat1 cat2 fun1 fun2 x z
+> commaCompose cat cat1 cat2 fun1 fun2 x y z u v = MkCommaMorphism
+>   (compose cat1 (comObj1 x) (comObj1 y) (comObj1 z) (comMor1 u) (comMor1 v))
+>   (compose cat2 (comObj2 x) (comObj2 y) (comObj2 z) (comMor2 u) (comMor2 v))
+>   (trans7
+>     (cong2 {f = compose cat _ _ _} (preserveCompose fun1 _ _ _ (comMor1 u) (comMor1 v)) Refl)
+>     (sym (associativity cat _ _ _ _ (mapMor fun1 _ _ (comMor1 u)) (mapMor fun1 _ _ (comMor1 v)) (comMor z)))
+>     (cong {f = compose cat _ _ _ _} (comSq v))
+>     (associativity cat _ _ _ _ _ _ _)
+>     (cong2 {f = compose cat _ _ _} (comSq u) Refl)
+>     (sym (associativity cat _ _ _ _ _ _ _))
+>     (sym (cong {f = compose cat _ _ _ _} (preserveCompose fun2 _ _ _(comMor2 u) (comMor2 v)))))
+>
+> commaLeftIdentity :
+>      (cat, cat1, cat2 : Category)
+>   -> (fun1 : CFunctor cat1 cat)
+>   -> (fun2 : CFunctor cat2 cat)
+>   -> (x, y : CommaObject cat cat1 cat2 fun1 fun2)
+>   -> (u : CommaMorphism cat cat1 cat2 fun1 fun2 x y)
+>   -> commaCompose cat cat1 cat2 fun1 fun2 x x y (commaIdentity cat cat1 cat2 fun1 fun2 x) u = u
+> commaLeftIdentity cat cat1 cat2 fun1 fun2 x y u = commaMorphismsEqual cat cat1 cat2 fun1 fun2 x y _ _ (leftIdentity cat1 _ _ (comMor1 u)) (leftIdentity cat2 _ _ (comMor2 u))
+>
+> commaRightIdentity :
+>      (cat, cat1, cat2 : Category)
+>   -> (fun1 : CFunctor cat1 cat)
+>   -> (fun2 : CFunctor cat2 cat)
+>   -> (x, y : CommaObject cat cat1 cat2 fun1 fun2)
+>   -> (u : CommaMorphism cat cat1 cat2 fun1 fun2 x y)
+>   -> commaCompose cat cat1 cat2 fun1 fun2 x y y u (commaIdentity cat cat1 cat2 fun1 fun2 y) = u
+> commaRightIdentity cat cat1 cat2 fun1 fun2 x y u = commaMorphismsEqual cat cat1 cat2 fun1 fun2 x y _ _ (rightIdentity cat1 _ _ (comMor1 u)) (rightIdentity cat2 _ _ (comMor2 u))
+>
+> commaAssociativity :
+>      (cat, cat1, cat2 : Category)
+>   -> (fun1 : CFunctor cat1 cat)
+>   -> (fun2 : CFunctor cat2 cat)
+>   -> (w, x, y, z : CommaObject cat cat1 cat2 fun1 fun2)
+>   -> (f : CommaMorphism cat cat1 cat2 fun1 fun2 w x)
+>   -> (g : CommaMorphism cat cat1 cat2 fun1 fun2 x y)
+>   -> (h : CommaMorphism cat cat1 cat2 fun1 fun2 y z)
+>   -> commaCompose cat cat1 cat2 fun1 fun2 _ _ _ f (commaCompose cat cat1 cat2 fun1 fun2 _ _ _ g h)
+>    = commaCompose cat cat1 cat2 fun1 fun2 _ _ _ (commaCompose cat cat1 cat2 fun1 fun2 _ _ _ f g) h
+> commaAssociativity cat cat1 cat2 fun1 fun2 w x y z f g h = commaMorphismsEqual cat cat1 cat2 fun1 fun2 w z _ _ (associativity cat1 _ _ _ _ (comMor1 f) (comMor1 g) (comMor1 h)) (associativity cat2 _ _ _ _ (comMor2 f) (comMor2 g) (comMor2 h))
+>
+> commaCategory :
+>      (cat, cat1, cat2 : Category)
+>   -> (fun1 : CFunctor cat1 cat)
+>   -> (fun2 : CFunctor cat2 cat)
+>   -> Category
+> commaCategory cat cat1 cat2 fun1 fun2 = MkCategory
+>   (CommaObject cat cat1 cat2 fun1 fun2)
+>   (CommaMorphism cat cat1 cat2 fun1 fun2)
+>   (commaIdentity cat cat1 cat2 fun1 fun2)
+>   (commaCompose cat cat1 cat2 fun1 fun2)
+>   (commaLeftIdentity cat cat1 cat2 fun1 fun2)
+>   (commaRightIdentity cat cat1 cat2 fun1 fun2)
+>   (commaAssociativity cat cat1 cat2 fun1 fun2)

--- a/src/Slice/OverCategory.lidr
+++ b/src/Slice/OverCategory.lidr
@@ -1,0 +1,34 @@
+\iffalse
+SPDX-License-Identifier: AGPL-3.0-only
+
+This file is part of `idris-ct` Category Theory in Idris library.
+
+Copyright (C) 2020 Stichting Statebox <https://statebox.nl>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+\fi 
+
+> module Slice.OverCategory
+>
+> import Basic.Category
+> import Basic.Functor
+> import Slice.Comma
+> import Unit.UnitCategory
+>
+>
+> overCategory : (cat : Category) -> obj cat -> Category
+> overCategory cat x = commaCategory cat cat unitCategory (idFunctor cat) (functorFromUnit cat x)
+>
+> overObject : (cat : Category) -> (x, y : obj cat) -> (f : mor cat x y) -> obj (overCategory cat y)
+> overObject cat x y f = MkCommaObject x () f

--- a/src/Slice/UnderCategory.lidr
+++ b/src/Slice/UnderCategory.lidr
@@ -1,0 +1,34 @@
+\iffalse
+SPDX-License-Identifier: AGPL-3.0-only
+
+This file is part of `idris-ct` Category Theory in Idris library.
+
+Copyright (C) 2020 Stichting Statebox <https://statebox.nl>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+\fi 
+
+> module Slice.UnderCategory
+>
+> import Basic.Category
+> import Basic.Functor
+> import Slice.Comma
+> import Unit.UnitCategory
+>
+>
+> underCategory : (cat : Category) -> obj cat -> Category
+> underCategory cat x = commaCategory cat unitCategory cat (functorFromUnit cat x) (idFunctor cat)
+>
+> underObject : (cat : Category) -> (x, y : obj cat) -> (f : mor cat x y) -> obj (underCategory cat x)
+> underObject cat x y f = MkCommaObject () y f

--- a/src/Unit/UnitCategory.lidr
+++ b/src/Unit/UnitCategory.lidr
@@ -1,0 +1,46 @@
+\iffalse
+SPDX-License-Identifier: AGPL-3.0-only
+
+This file is part of `idris-ct` Category Theory in Idris library.
+
+Copyright (C) 2020 Stichting Statebox <https://statebox.nl>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+\fi 
+
+> module Unit.UnitCategory
+>
+> import Basic.Category
+> import Basic.Functor
+> import Discrete.DiscreteCategory
+> import Discrete.FunctionAsFunctor
+>
+>
+> %access public export
+> %default total
+> %auto_implicits off
+>
+> -- Could hand-roll a unit category, which would have the effect that the homtype was () rather than ()=()
+> unitCategory : Category
+> unitCategory = discreteCategory ()
+>
+> functorFromUnit : (cat : Category) -> (x : obj cat) -> CFunctor unitCategory cat
+> functorFromUnit cat x = discreteFunctor (\ _ => x)
+>
+> functorToUnit : (cat : Category) -> CFunctor cat unitCategory
+> functorToUnit cat = MkCFunctor
+>   (\ a => ())
+>   (\ _, _, f => Refl)
+>   (\ _ => Refl)
+>   (\ _, _, _, _, _ => Refl)

--- a/src/Utils.lidr
+++ b/src/Utils.lidr
@@ -38,3 +38,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 >       -> snd x = snd y
 >       -> x = y
 > pairEq {x=(n, m)} {y=(n, m)} Refl Refl = Refl
+>
+> equalitiesEqual : (p, q : x = y) -> p = q
+> equalitiesEqual {x = x} {y = _} Refl Refl = Refl
+
+We provide some helper functions, trans3, trans4, and so on; these make lengthy
+diagram chase proofs slightly easier to read.
+
+> trans3 : {a:w} -> {b:x} -> {c:y} -> {d:z}
+>   -> a = b -> b = c -> c = d -> a = d
+> trans3 Refl Refl Refl = Refl
+>
+> trans4 : {a:v} -> {b:w} -> {c:x} -> {d:y} -> {e:z}
+>   -> a = b -> b = c -> c = d -> d = e -> a = e
+> trans4 Refl Refl Refl Refl = Refl
+>
+> trans5 : {a:u} -> {b:v} -> {c:w} -> {d:x} -> {e:y} -> {f:z}
+>   -> a = b -> b = c -> c = d -> d = e -> e = f -> a = f
+> trans5 Refl Refl Refl Refl Refl = Refl
+>
+> trans6 : {a:t} -> {b:u} -> {c:v} -> {d:w} -> {e:x} -> {f:y} -> {g:z}
+>   -> a = b -> b = c -> c = d -> d = e -> e = f -> f = g -> a = g
+> trans6 Refl Refl Refl Refl Refl Refl = Refl
+>
+> trans7 : {a:s} -> {b:t} -> {c:u} -> {d:v} -> {e:w} -> {f:x} -> {g:y} -> {h:z}
+>   -> a = b -> b = c -> c = d -> d = e -> e = f -> f = g -> g = h -> a = h
+> trans7 Refl Refl Refl Refl Refl Refl Refl = Refl


### PR DESCRIPTION
The previous code wasn't used elsewhere; this should be useful in all the same circumstances but is significantly more general (it builds functors from discrete categories to any category, not merely from discrete categories to other discrete categories).